### PR TITLE
fix travisci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
-  - 2.3
+  - 2.7
+before_install:
+  - gem install bundler
 script:
   - bundle exec jekyll build
 env:


### PR DESCRIPTION
Upgrade ruby and bundler versions to match what is used by the project.  These versions fix the broken build.